### PR TITLE
Create method with empty parenthesis

### DIFF
--- a/library/src/main/scala/treehugger/TreePrinters.scala
+++ b/library/src/main/scala/treehugger/TreePrinters.scala
@@ -340,7 +340,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
           print("def " + symName(tree, name))
           printTypeParams(tparams)
           vparamss match {
-            case List() | List(List()) => //
+            case List() => //
             case _ => vparamss foreach printValueParams
           }
           if (!rhs.isEmpty)
@@ -359,7 +359,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
           print("def " + symName(tree, name))
           printTypeParams(tparams)
           vparamss match {
-            case List() | List(List()) => //
+            case List() => //
             case _ => vparamss foreach printValueParams
           }
           printOpt(": ", tp)

--- a/library/src/main/scala/treehugger/treehuggerdsls.scala
+++ b/library/src/main/scala/treehugger/treehuggerdsls.scala
@@ -354,7 +354,7 @@ trait TreehuggerDSLs { self: Forest =>
     }
     
     trait VparamssStart {
-      private var _vparamss: List[List[ValDef]] = List(Nil)
+      private var _vparamss: List[List[ValDef]] = Nil
       
       def withParams(param: ValDef*): this.type = withParams(param.toList)
       def withParams(param: Iterable[ValDef]): this.type = {

--- a/library/src/test/scala/DSL_1BasicDeclSpec.scala
+++ b/library/src/test/scala/DSL_1BasicDeclSpec.scala
@@ -150,11 +150,12 @@ limit them to some members.                                                   $i
   }
 
   def function1 =
-    (DEF("get", IntClass): Tree) must print_as("def get: Int")
+    DEF("get", IntClass).tree must print_as("def get: Int")
     
   def function2 =
     ((DEF("put", UnitClass) withParams(PARAM("x", IntClass)): Tree) must print_as("def put(x: Int): Unit")) and
-    ((DEF(sym.run, UnitClass) withParams(PARAM("x", IntClass) := LIT(0)): Tree) must print_as("def run(x: Int = 0): Unit"))
+    ((DEF(sym.run, UnitClass) withParams(PARAM("x", IntClass) := LIT(0)): Tree) must print_as("def run(x: Int = 0): Unit")) and
+    ((DEF("sideEffect", UnitClass) withParams()).tree must print_as("def sideEffect(): Unit"))
 
   def function3 =
     (DEF("compare", BooleanClass)

--- a/notes/0.4.0.markdown
+++ b/notes/0.4.0.markdown
@@ -1,4 +1,5 @@
   [22]: https://github.com/eed3si9n/treehugger/issues/22
+  [23]: https://github.com/eed3si9n/treehugger/issues/23
 
 ## Breaking change: Procedures
 
@@ -34,3 +35,15 @@ This prints as
 
 `DEF("x") := BLOCK(...)` will now throw an exception.
 rhs that's not a `BLOCK(...)` will continue to work as before.
+
+## Breaking change: Empty parameter list
+
+Starting treehugger 0.4.0 `withParams()` will print as an empty parameter list. [#23][23]
+
+    DEF("greet", UnitClass) withParams() := BLOCK(Predef_println APPLY LIT("Hello, world!"))
+
+This prints as
+
+    def greet(): Unit = {
+      println("Hello, world!")
+    }


### PR DESCRIPTION
Hi!

I'm using treehugger to generate wrapper code for an API in Scala.js.
One problem I'm facing is that when Scala.js encounters a method
```scala
def get: Int
```
it transforms this into something like
```javascript
obj["get"]
```
whereas
```scala
def get(): Int
```
is correctly transformed into
```javascript
obj["get"]()
```
(note the parenthesis at the end).
As empty parenthesis are also used in normal Scala to denote a method with side-effects, I was wondering if treehugger supports generating such methods.
Actually, the documentation [contains an example](http://eed3si9n.com/treehugger/Combined+Pages.html#Classy+example) where a method with empty parenthesis is generated, but I can't reproduce that locally.

If you point me in the right direction I can also try to create a PR for this.

Thanks!
  Martin