### PR TITLE
change DocGen to trim trailing whitespace

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import UnidocKeys._
 
 val commonSettings = Seq(
     organization := "com.eed3si9n",
-    version := "0.4.1",
+    version := "0.4.2-SNAPSHOT",
     scalaVersion := "2.11.4",
     crossScalaVersions := Seq("2.11.6", "2.10.5"),
     homepage := Some(url("http://eed3si9n.com/treehugger")),

--- a/library/src/main/scala/treehugger/TreePrinters.scala
+++ b/library/src/main/scala/treehugger/TreePrinters.scala
@@ -82,11 +82,11 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
         }{print(", ")}; print("]")
       }
     }
-    
+
     def printValueParams(ts: List[ValDef]) {
       printValueParams(ts, false)
     }
-    
+
     def printValueParams(ts: List[ValDef], isclass: Boolean) {
       print("(")
       if (!ts.isEmpty) printFlags(ts.head.mods.flags & IMPLICIT, "")
@@ -190,11 +190,11 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
 
     def printAnnotation(annot: AnnotationInfo) {
       print("@", annot.atp)
-      
+
       if (!annot.args.isEmpty) printRow(annot.args, "(", ", ", ")")
       else if (!annot.assocs.isEmpty)
         print(annot.assocs map { case (x, y) => x+" = "+y } mkString ("(", ", ", ")"))
-      
+
       print(" ")
     }
 
@@ -205,15 +205,15 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
         lines foreach { line =>
           print("// ", line)
           println()
-        } 
+        }
       else if (count == 1) {
         print("/** ", lines.head, " */")
         println()
       } else {
         print("/**")
-        println()        
+        println()
         lines foreach { line =>
-          print(" * ", line)
+          print(s" * $line".replaceAll("""(?m)\s+$""", ""))
           println()
         }
         print(" */")
@@ -237,7 +237,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
 
     private var currentOwner: Symbol = NoSymbol
     private var selectorType: Type = NoType
-    
+
     def typeTreeToString(tt: TypeTree): String =
       if ((tt.tpe eq null) || (doPrintPositions && tt.original != null)) {
         if (tt.original != null) "<type: " + tt.original + ">"
@@ -262,7 +262,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
         case x: New => true
         case x: Typed => true
         case x: TypeApply => true
-        
+
         case _ => false
       }
 
@@ -273,10 +273,10 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
       tree match {
         case EmptyTree =>
           print("")
-        
+
         case classdef: ClassDef if classdef.name == tpnme.ANON_CLASS_NAME =>
            print(classdef.impl)
-        
+
         case ClassDef(mods, ctormods, name, tparams, vparams, impl) =>
           printAnnotations(tree)
           printModifiers(tree, mods)
@@ -292,14 +292,14 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
             printModifiers(tree, ctormods)
           }
           if (vparams != Nil) printValueParams(vparams, true)
-          
+
           print(if (mods.isDeferred) " <: "
                 else if (impl.parents.isEmpty) ""
                 else " extends ", impl)
 
         case PackageDef(mods, packaged, stats) =>
           printAnnotations(tree)
-          
+
           if (packaged != NoPackage)
             print("package ", packaged)
 
@@ -317,7 +317,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
           printModifiers(tree, mods);
           if (mods.hasFlag(Flags.PACKAGE)) print("package ")
           print("object " + symName(tree, name))
-          if (impl.parents.isEmpty) print("") 
+          if (impl.parents.isEmpty) print("")
           else print(" extends ")
           print(impl)
 
@@ -325,7 +325,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
           printAnnotations(tree)
           printModifiers(tree, mods)
           print(if (mods.isMutable) "var " else "val ")
-          
+
           // , symName(tree, name)
           lhs match {
             case Typed(expr, tpt) => print(expr, ": ", tpt)
@@ -352,7 +352,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
                   print(" "); indent; println(); print(rhs); undent
                 }
             }
-            
+
         case DefDef(mods, name, tparams, vparamss, tp, rhs) =>
           printAnnotations(tree)
           printModifiers(tree, mods)
@@ -372,7 +372,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
                   print(" ="); indent; println(); print(rhs); undent
                 }
             }
-        
+
         case AnonFunc(vparamss, tp: TypeTree, rhs: Block) =>
           print("{ ")
           if (vparamss.size == 1) printLambdaParams(vparamss.head)
@@ -380,13 +380,13 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
           print(" =>")
           printColumn(rhs.stats ::: List(rhs.expr), "", "", "")
           print("}")
-          
+
         case AnonFunc(vparamss, tp: TypeTree, rhs) =>
           if (vparamss.size == 1) printLambdaParams(vparamss.head)
           else vparamss foreach printValueParams
           printOpt(": ", tp)
           if (!rhs.isEmpty) print(" => ", rhs)
-                              
+
         case TypeDef(mods, name, tparams, rhs) =>
           if (mods hasFlag (PARAM | DEFERRED)) {
             printAnnotations(tree)
@@ -428,7 +428,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
             else from + " => " + quotedName(s.rename)
           }
           print("import ", backquotedPath(expr))
-          
+
           if (selectors.isEmpty) print("")
           else selectors match {
             case List(s) =>
@@ -536,7 +536,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
 
         case TypeApply(fun, targs) =>
           print(fun); printRow(targs, "[", ", ", "]")
-        
+
         case Apply(fun, vargs) =>
           if (!isTupleTree(tree)) print(fun)
           if (vargs.size == 1
@@ -562,7 +562,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
         case This(qual) =>
           if (!qual.isEmpty) print(symName(tree, qual) + ".")
           print("this")
-        
+
         case Select(qualifier, name) if unaryop(name).isDefined =>
           print(unaryop(name).get, "(", qualifier, ")")
 
@@ -571,11 +571,11 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
 
         case Select(Literal(x), name) =>
           print(x.escapedStringValue, ".", symName(tree, name))
-        
+
         case Select(qualifier, name) =>
           print(qualifier, ".", symName(tree, name))
           // print(backquotedPath(qualifier), ".", symName(tree, name))
-                
+
         case Ident(name) =>
           tree match {
             case BackQuotedIdent(name) =>
@@ -588,7 +588,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
 
         case tt: TypeTree =>
           print(typeTreeToString(tt))
-          
+
         case Annotated(Apply(Select(New(tpt), nme.CONSTRUCTOR), args), tree) =>
           def printAnnot() {
             print("@", tpt)
@@ -625,7 +625,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
             indent(); println();
             print(body)
             undent()
-          } 
+          }
           else {
             printColumn(enumerators, "{", "", "} ")
             print(body)
@@ -637,28 +637,28 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
             indent(); println();
             print("yield "); print(body)
             undent()
-          } 
+          }
           else {
             printColumn(enumerators, "{", "", "} ")
             print("yield "); print(body)
-          }          
+          }
         case ForValFrom(_, name, tp, rhs) =>
           print(symName(tree, name))
           printOpt(": ", tp)
-          print(" <- ", rhs)  
+          print(" <- ", rhs)
         case ForValDef(_, name, tp, rhs) =>
           print(symName(tree, name))
           printOpt(": ", tp)
-          print(" = ", rhs)  
+          print(" = ", rhs)
         case ForFilter(_, test: Tree) =>
           print("if ", test)
         case Infix(Literal(x), name, args) =>
           print(x.escapedStringValue, " ", symName(tree, name))
           if (!args.isEmpty) {
             print(" ")
-            if (args.size == 1) 
+            if (args.size == 1)
              args(0) match {
-                case x: Infix => print("(", x, ")") 
+                case x: Infix => print("(", x, ")")
                 case _        => print(args(0))
              }
             else printRow(args, "(", ", ", ")")
@@ -667,9 +667,9 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
           print(qualifier, " ", symName(tree, name))
           if (!args.isEmpty) {
             print(" ")
-            if (args.size == 1) 
+            if (args.size == 1)
              args(0) match {
-                case x: Infix => print("(", x, ")") 
+                case x: Infix => print("(", x, ")")
                 case _        => print(args(0))
              }
             else printRow(args, "(", ", ", ")")
@@ -680,9 +680,9 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
           else printRow(args, "(", ", ", ")")
         case InfixUnApply(qualifier, name, args) =>
           print(qualifier, " ", symName(tree, name), " ")
-          if (args.size == 1) 
+          if (args.size == 1)
             args(0) match {
-              case x: Infix => print("(", x, ")") 
+              case x: Infix => print("(", x, ")")
               case _        => print(args(0))
             }
           else printRow(args, "(", ", ", ")")
@@ -721,11 +721,11 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
   def newTreePrinter(writer: PrintWriter): TreePrinter = new TreePrinter(writer)
   def newTreePrinter(stream: OutputStream): TreePrinter = newTreePrinter(new PrintWriter(stream))
   def newTreePrinter(): TreePrinter = newTreePrinter(new PrintWriter(ConsoleWriter))
-    
+
   def treeToString(args: Any*): String = {
     val sw = new StringWriter
     val writer = new PrintWriter(sw)
-    val printer = newTreePrinter(writer)  
+    val printer = newTreePrinter(writer)
     args.toList match {
       case Nil => //
       case List(x) => printer.print(x)
@@ -733,13 +733,13 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
         printer.print(x)
         xs foreach { arg =>
           printer.println()
-          printer.print(arg) 
+          printer.print(arg)
         }
     }
 
     sw.toString
   }
-  
+
   /** A writer that writes to the current Console and
    * is sensitive to replacement of the Console's
    * output stream.

--- a/library/src/test/scala/DSL_0LexicalSpec.scala
+++ b/library/src/test/scala/DSL_0LexicalSpec.scala
@@ -16,7 +16,7 @@ class DSL_0LexicalSpec extends DSLSpec { def is =                             s2
   Scaladoc style comments are written as
     `tree withDoc("a")` or withDoc("a", DocTag.See(IntClass), ...).           $comment2
                                                                               """
-  
+
   import treehugger.forest._
   import definitions._
   import treehuggerDSL._
@@ -24,13 +24,13 @@ class DSL_0LexicalSpec extends DSLSpec { def is =                             s2
   def literal1 =
     (LIT("Hello") must print_as("\"Hello\"")) and
     (LIT('H') must print_as("'H'"))
-  
+
   def literal2 =
     (LIT(1)    must print_as("1")) and
     (LIT(1.23) must print_as("1.23")) and
     (LIT(1L)   must print_as("1L")) and
     (LIT(1.23F) must print_as("1.23F"))
-  
+
   def literal3 =
     LIT('Symbol) must print_as("'Symbol")
 
@@ -39,7 +39,7 @@ class DSL_0LexicalSpec extends DSLSpec { def is =                             s2
     (FALSE must print_as("false")) and
     (NULL  must print_as("null")) and
     (UNIT  must print_as("()"))
-    
+
   def comment1 =
     (LIT(2) withComment("if you have to explain yourself", "in comments...")) must print_as(
       "// if you have to explain yourself",
@@ -55,11 +55,20 @@ class DSL_0LexicalSpec extends DSLSpec { def is =                             s2
     ((DEF("x").tree withDoc("does \nsomething",
         DocTag.See(IntClass), DocTag.ToDo(IntClass, "foo"))) must print_as(
       "/**",
-      " * does ",
+      " * does",
       " * something",
       " * @see scala.Int",
       " * @todo scala.Int foo",
       " */",
       "def x"
+    )) and
+    ((DEF("x").tree withDoc("has \n\nno trailing whitespace")) must print_as(
+      "/**",
+      " * has",
+      " *",
+      " * no trailing whitespace",
+      " */",
+      "def x"
     ))
+    
 }


### PR DESCRIPTION
Hi,

Really been enjoying using Treehugger to [generate Scala case classes base on Avro schemas](https://github.com/julianpeeters/avrohugger), thanks a lot!

For your consideration, here's a patch the gets DocGen conforming to the current [style guide](http://docs.scala-lang.org/style/scaladoc.html). I notice that this [wiki](https://wiki.scala-lang.org/display/SW/Scaladoc) states that your current implementation is correct, but it seems to be outdated.

I guess it's possible that the current style guide is incorrectly rendered in HTML, but that illustrates the problem I'm having in certain code editors, hence this submission.

To elaborate, sometimes I use Atom to edit Scala, and it is pretty aggressive when it comes to automatically removing whitespace (which means they get removed from my test Strings! - that was a mystery for a good while!). It's not the worst situation, since I have other, functional tests, and I can be careful to use certain editors when working on particular test files, but it's a land mine to open, edit, save, and accidentally lose the whitespace that some libraries generate.

So, I'm good for now if I'm careful, but thought you might like to have  a look. Thanks again for all the code,

Julian