### PR TITLE
Use println for annotations of declarations and definitions

### DIFF
--- a/library/src/main/scala/treehugger/TreePrinters.scala
+++ b/library/src/main/scala/treehugger/TreePrinters.scala
@@ -187,6 +187,14 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
       }
       annots foreach (printAnnotation)
     }
+    
+    def printlnAnnotations(tree: Tree) {
+      val annots = tree.symbol.annotations match {
+        case Nil  => tree.asInstanceOf[MemberDef].mods.annotations
+        case anns => anns
+      }
+      annots foreach (printlnAnnotation)
+    }
 
     def printAnnotation(annot: AnnotationInfo) {
       print("@", annot.atp)
@@ -196,6 +204,16 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
         print(annot.assocs map { case (x, y) => x+" = "+y } mkString ("(", ", ", ")"))
       
       print(" ")
+    }
+    
+    def printlnAnnotation(annot: AnnotationInfo) {
+      print("@", annot.atp)
+      
+      if (!annot.args.isEmpty) printRow(annot.args, "(", ", ", ")")
+      else if (!annot.assocs.isEmpty)
+        print(annot.assocs map { case (x, y) => x+" = "+y } mkString ("(", ", ", ")"))
+      
+      println
     }
 
     def printComment(mods: Modifiers, comments: List[String]) {
@@ -278,7 +296,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
            print(classdef.impl)
         
         case ClassDef(mods, ctormods, name, tparams, vparams, impl) =>
-          printAnnotations(tree)
+          printlnAnnotations(tree)
           printModifiers(tree, mods)
           val word =
             if (mods.hasTraitFlag) "trait"
@@ -298,7 +316,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
                 else " extends ", impl)
 
         case PackageDef(mods, packaged, stats) =>
-          printAnnotations(tree)
+          printlnAnnotations(tree)
           
           if (packaged != NoPackage)
             print("package ", packaged)
@@ -313,7 +331,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
           else printColumn(stats, " {", "", "}")
 
         case ModuleDef(mods, name, impl) =>
-          printAnnotations(tree)
+          printlnAnnotations(tree)
           printModifiers(tree, mods);
           if (mods.hasFlag(Flags.PACKAGE)) print("package ")
           print("object " + symName(tree, name))
@@ -322,7 +340,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
           print(impl)
 
         case ValDef(mods, lhs, rhs) =>
-          printAnnotations(tree)
+          printlnAnnotations(tree)
           printModifiers(tree, mods)
           print(if (mods.isMutable) "var " else "val ")
           
@@ -335,7 +353,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
             print(" = ", rhs)
 
         case ProcDef(mods, name, tparams, vparamss, rhs) =>
-          printAnnotations(tree)
+          printlnAnnotations(tree)
           printModifiers(tree, mods)
           print("def " + symName(tree, name))
           printTypeParams(tparams)
@@ -354,7 +372,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
             }
             
         case DefDef(mods, name, tparams, vparamss, tp, rhs) =>
-          printAnnotations(tree)
+          printlnAnnotations(tree)
           printModifiers(tree, mods)
           print("def " + symName(tree, name))
           printTypeParams(tparams)

--- a/library/src/test/scala/DSL_7AnnotationSpec.scala
+++ b/library/src/test/scala/DSL_7AnnotationSpec.scala
@@ -19,7 +19,8 @@ class DSL_7AnnotationSpec extends DSLSpec { def is =                          s2
     (CLASSDEF("C") withAnnots(ANNOT(SerializableAttr)) := BLOCK(
       DEF("get", IntClass)
     )) must print_as(
-      """@serializable class C {""",
+      """@serializable""",
+      """class C {""",
       """  def get: Int""",
       """}"""
     )


### PR DESCRIPTION
Hi Eugene,

Man, I just love treehugger. It's seriously one of my favorite things to use. Recently I ran into another style issue that's not really a problem for me, but I thought I'd give you an opportunity to see what works best for me. No worries if you'd rather not merge, keeping things as is.

My issue is that I'm generating a trait with multiple annotations:

```
@annotation1 @annotation2 @annotation3 trait MyTrait {
  ... 
}
```

Works fine, but the trait's name (and the fact that it's a trait) ends up getting lost among all the annotations. For my use case the following is much clearer:

```
@annotation1
@annotation2
@annotation3
trait MyTrait {
  ... 
}
```

Maybe I've just overlooked a way to accomplish this in treehugger 0.4.1?

I've got a decent workaround, which is to define my `ANNOT`s with `String`s that have an extra `"\n\b"` at the end (the `\n` giving the linebreak, and the `\b` erasing the now extra space ` `). This works perfectly until I start nesting defintions, and then indention breaks:

```
@annotation1
@annotation2
trait MyTrait {

  @annotation1
trait MyTrait {
    ... 
  } 

}
```

In case you are interested in supporting this, here's a PR that adds printlnAnnotations and printlnAnnotation methods to support improved formatting of multi-annotated declarations and definitions: ClassDef, PackageDef, ModuleDef, ValDef, ProcDef, DefDef. Other annotation contexts such as expressions and TypeDefs remain as same-line annotations.

Of course, this is just a style tradeoff (so apologies for wasting your brain power on this!), and is to the detriment of short and simple annotated definitions like:

```
@annotation1 @annotation2 val x: Int = 1
@annotation1 @annotation2 val y: Int = 2
```

And maybe those could even be retained by removing `pritnlnAnnotations` and adding a `ClassDef`, `PackageDef`, etc. matcher to `printAnnotations`, with guard that checks that `treeToString(tree)` will fit on a single line, and routes the trees to `printAnnotation` or `printlnAnnotation` accordingly. Say the words and I'll be happy to add that to the PR.
