### PR TITLE
Revert "Change DogGen from JavaDoc style to ScalaDoc style"

### DIFF
--- a/library/src/main/scala/treehugger/TreePrinters.scala
+++ b/library/src/main/scala/treehugger/TreePrinters.scala
@@ -228,13 +228,13 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
         print("/** ", lines.head, " */")
         println()
       } else {
-        print("/** ", lines.headOption.getOrElse(""))
+        print("/**")
         println()        
-        lines.tail foreach { line =>
-          print("  * ", line)
+        lines foreach { line =>
+          print(" * ", line)
           println()
         }
-        print("  */")
+        print(" */")
         println()
       }
     }

--- a/library/src/test/scala/DSL_0LexicalSpec.scala
+++ b/library/src/test/scala/DSL_0LexicalSpec.scala
@@ -54,11 +54,12 @@ class DSL_0LexicalSpec extends DSLSpec { def is =                             s2
     )) and
     ((DEF("x").tree withDoc("does \nsomething",
         DocTag.See(IntClass), DocTag.ToDo(IntClass, "foo"))) must print_as(
-      "/** does ",
-      "  * something",
-      "  * @see scala.Int",
-      "  * @todo scala.Int foo",
-      "  */",
+      "/**",
+      " * does ",
+      " * something",
+      " * @see scala.Int",
+      " * @todo scala.Int foo",
+      " */",
       "def x"
     ))
 }


### PR DESCRIPTION
This reverts commit 9ed4fb21ec3ed63cd2d832f8aab5d166e2193248.

Ref #30