### PR TITLE
A fix for issue #44: case classes with an empty parameter list should be printed with parenthesis

### DIFF
--- a/library/src/main/scala/treehugger/TreePrinters.scala
+++ b/library/src/main/scala/treehugger/TreePrinters.scala
@@ -7,6 +7,7 @@ package treehugger
 
 import java.io.{ OutputStream, PrintWriter, StringWriter, Writer }
 import Flags._
+import treehugger.api.Modifier
 
 trait TreePrinters extends api.TreePrinters { self: Forest =>
 
@@ -309,7 +310,8 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
             print(" ")
             printModifiers(tree, ctormods)
           }
-          if (vparams != Nil) printValueParams(vparams, true)
+          if (vparams != Nil || modifiersOfFlags(mods.flags).contains(Modifier.`case`))
+            printValueParams(vparams, true)
           
           print(if (mods.isDeferred) " <: "
                 else if (impl.parents.isEmpty) ""

--- a/library/src/test/scala/DSL_2ClassSpec.scala
+++ b/library/src/test/scala/DSL_2ClassSpec.scala
@@ -120,7 +120,7 @@ sealed classes `withFlags(Flags.SEALED)`.                                     $c
     )
 
   def caseclass1 =
-    ((CASECLASSDEF("C"): Tree) must print_as("case class C")) and
+    ((CASECLASSDEF("C"): Tree) must print_as("case class C()")) and
     ((CASECLASSDEF("C") withParams(VAL("x", IntClass) withFlags(Flags.OVERRIDE)) withParents(sym.Addressable APPLY(REF("x"))) := BLOCK(
       DEF("y") := LIT(0)
     ))


### PR DESCRIPTION
Hi,

This is an attempt to provide a fix for issue #44 by suggesting that "case classes with an empty parameter list should be printed with parenthesis".

I hope this helps.

Best regards,

Joseph.
 