### PR TITLE
fix adaptation argument warning

### DIFF
--- a/library/src/main/scala/treehugger/TreeGen.scala
+++ b/library/src/main/scala/treehugger/TreeGen.scala
@@ -243,7 +243,7 @@ trait TreeGen { self: Forest =>
    */
   def mkZero(tp: Type): Tree = {
     val tree = tp.typeSymbol match {
-      case UnitClass    => Literal(Constant())
+      case UnitClass    => Literal(Constant(()))
       case BooleanClass => Literal(Constant(false))
       case FloatClass   => Literal(Constant(0.0f))
       case DoubleClass  => Literal(Constant(0.0d))
@@ -259,7 +259,7 @@ trait TreeGen { self: Forest =>
 
   /** Builds a tuple */
   def mkTuple(elems: List[Tree]): Tree =
-    if (elems.isEmpty) Literal(Constant())
+    if (elems.isEmpty) Literal(Constant(()))
     else Apply(
       TupleClass(elems.length),
       elems: _*)


### PR DESCRIPTION
https://travis-ci.org/eed3si9n/treehugger/jobs/399664958#L799

```
[warn] /home/travis/build/eed3si9n/treehugger/library/src/main/scala/treehugger/TreeGen.scala:246: Adaptation of argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous.
[warn]         signature: Constant.apply(value: Any): Constants.this.Constant
[warn]   given arguments: <none>
[warn]  after adaptation: Constant((): Unit)
[warn]       case UnitClass    => Literal(Constant())
[warn]                                            ^
[warn] /home/travis/build/eed3si9n/treehugger/library/src/main/scala/treehugger/TreeGen.scala:262: Adaptation of argument list by inserting () is deprecated: leaky (Object-receiving) target makes this especially dangerous.
[warn]         signature: Constant.apply(value: Any): Constants.this.Constant
[warn]   given arguments: <none>
[warn]  after adaptation: Constant((): Unit)
[warn]     if (elems.isEmpty) Literal(Constant())
[warn]                                        ^
```