### PR TITLE
build improvements (most notably, JDK 11+ friendliness)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 rsync.sh
 www
 *.tar.gz
+target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,11 @@ jdk:
   - openjdk8
   - openjdk11
 
-script:
-  - sbt "++${TRAVIS_SCALA_VERSION}" "${SBT_CMD}"
+scala:
+  - 2.10.7
+  - 2.11.12
+  - 2.12.9
+  - 2.13.0
 
-matrix:
-  include:
-  - env: SBT_CMD="test"
-    scala: 2.10.7
-  - env: SBT_CMD="test"
-    scala: 2.11.12
-  - env: SBT_CMD="test"
-    scala: 2.12.9
-  - env: SBT_CMD="test"
-    scala: 2.13.0
+script:
+  - sbt "++${TRAVIS_SCALA_VERSION}" test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
   - env: SBT_CMD="test"
     scala: 2.11.12
   - env: SBT_CMD="test"
-    scala: 2.12.6
+    scala: 2.12.9
   - env: SBT_CMD="test"
     scala: 2.13.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-sudo: false
-
 language: scala
 
-jdk: openjdk8
+jdk:
+  - openjdk8
+  - openjdk11
 
 script:
   - sbt "++${TRAVIS_SCALA_VERSION}" "${SBT_CMD}"

--- a/library/src/main/scala/treehugger/TreePrinters.scala
+++ b/library/src/main/scala/treehugger/TreePrinters.scala
@@ -218,7 +218,7 @@ trait TreePrinters extends api.TreePrinters { self: Forest =>
     }
 
     def printComment(mods: Modifiers, comments: List[String]): Unit = {
-      val lines = comments flatMap {_.lines.toList}
+      val lines = comments flatMap {_.linesIterator.toList}
       val count = lines.size
       if (mods.flags == 0L)
         lines foreach { line =>

--- a/library/src/test/scala/DSLSpec.scala
+++ b/library/src/test/scala/DSLSpec.scala
@@ -22,6 +22,6 @@ trait DSLSpec extends Specification {
         (s == x, s + " doesn't equal " + x)
       case list    => 
         val s = treeToString(actual); println(s)
-        (s.lines.toList == list, s.lines.toList + " doesn't equal " + list)
+        (s.linesIterator.toList == list, s.linesIterator.toList + " doesn't equal " + list)
     }) 
 }

--- a/library/src/test/scala/TreePrinterSpec.scala
+++ b/library/src/test/scala/TreePrinterSpec.scala
@@ -24,7 +24,7 @@ class TreePrinterSpec extends DSLSpec { def is = sequential                   ^
       Predef_println APPLY LIT("Hello, world!"))
     val s = treeToString(tree); println(s)
     
-    s.lines.toList must contain(allOf(
+    s.linesIterator.toList must contain(allOf(
       """def hello {""",
       """  println("Hello, world!")""",
       """}"""
@@ -47,7 +47,7 @@ class TreePrinterSpec extends DSLSpec { def is = sequential                   ^
     
     val s = treeToString(tree); println(s)
     
-    s.lines.toList must contain(allOf(
+    s.linesIterator.toList must contain(allOf(
       "val greetStrings = new Array[String](3)",
       "",
       "greetStrings(0) = \"Hello\"",
@@ -83,7 +83,7 @@ class TreePrinterSpec extends DSLSpec { def is = sequential                   ^
       )) withComment("In file ChecksumAccumulator.scala")
     
     val out = treeToString(tree); println(out)
-    out.lines.toList must contain(allOf(
+    out.linesIterator.toList must contain(allOf(
       """// In file ChecksumAccumulator.scala""",
       """object ChecksumAccumulator {""",
       """  private val cache = scala.collection.mutable.Map[String, Int]()""",
@@ -131,7 +131,7 @@ class TreePrinterSpec extends DSLSpec { def is = sequential                   ^
       Nil
     
     val out = treeToString(trees: _*); println(out)
-    out.lines.toList must contain(allOf(
+    out.linesIterator.toList must contain(allOf(
       """abstract class IntQueue {""",
       """  def get: Int""",
       """  def put(x: Int)""",
@@ -170,7 +170,7 @@ class TreePrinterSpec extends DSLSpec { def is = sequential                   ^
       )) inPackage(ScalaPackageClass)
     
     val out = treeToString(tree); println(out)
-    out.lines.toList must contain(allOf(
+    out.linesIterator.toList must contain(allOf(
       """package scala""",
       """""",
       """object Predef {""",
@@ -202,7 +202,7 @@ class TreePrinterSpec extends DSLSpec { def is = sequential                   ^
         ))
     
     val out = treeToString(tree); println(out)
-    out.lines.toList must contain(allOf(
+    out.linesIterator.toList must contain(allOf(
       """def maxListUpBound[T <: Ordered[T]](elements: List[T]): T =""",
       """  elements match {""",
       """    case List() => throw new IllegalArgumentException("empty list!")""",
@@ -236,7 +236,7 @@ class TreePrinterSpec extends DSLSpec { def is = sequential                   ^
       ))
       
     val out = treeToString(tree); println(out)
-    out.lines.toList must contain(allOf(
+    out.linesIterator.toList must contain(allOf(
       """case class Address[T <% List[T]](name: Option[T] = None) {""",
       """  def stringOnly(implicit ev: =:=[T, String]): Address = Address(this.name map { (nm: String) =>""",
       """    val list: List[T] = nm""",
@@ -257,7 +257,7 @@ class TreePrinterSpec extends DSLSpec { def is = sequential                   ^
       ))
     
     val out = treeToString(tree); println(out)
-    out.lines.toList must contain(allOf(
+    out.linesIterator.toList must contain(allOf(
       "new Addressable {",
       "  val street = \"123 Drive\"",
       "}"
@@ -287,7 +287,7 @@ class TreePrinterSpec extends DSLSpec { def is = sequential                   ^
       )))
     
     val out = treeToString(tree); println(out)
-    out.lines.toList must contain(allOf(
+    out.linesIterator.toList must contain(allOf(
       "implicit def mkPointed[M : Monoid] = new Pointed[({ type L[A] = Const[M, A] })#L] {",
       "  def point[A](a: => A) = Const[M, A](implicitly[Monoid[M]].z)",
       "}"


### PR DESCRIPTION
the compilation failures on JDK 11+ turned up in the community build: https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk11-integrate-community-build/816/artifact/logs/treehugger-build.log