### PR TITLE
Cross scala versions management in one place

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,6 @@ import UnidocKeys._
 val commonSettings = Seq(
     organization := "com.eed3si9n",
     version := "0.4.4-SNAPSHOT",
-    scalaVersion := "2.11.12",
-    crossScalaVersions := Seq("2.12.9", "2.13.0", "2.11.12", "2.10.7"),
     homepage := Some(url("http://eed3si9n.com/treehugger")),
     licenses := Seq("MIT License" -> url("http://www.opensource.org/licenses/mit-license.php")),
     description := "a library to code Scala programmatically.",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 //addSbtPlugin("com.eed3si9n" % "sbt-pamflet" % "0.1.0-SNAPSHOT")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 //addSbtPlugin("com.eed3si9n" % "sbt-pamflet" % "0.1.0-SNAPSHOT")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.0")
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")

--- a/project/unidoc.sbt
+++ b/project/unidoc.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.0")


### PR DESCRIPTION
This PR adds https://github.com/dwijnand/sbt-travisci to allow manage cross Scala versions in one place (`.travis.yml`).
I hope this makes it easy to update for upcoming releases.