### PR TITLE
bump Scala versions (2.12.10->11, 2.13.1->3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ jdk:
 scala:
   - 2.10.7
   - 2.11.12
-  - 2.12.10
-  - 2.13.1
+  - 2.12.11
+  - 2.13.3
 
 script:
   - sbt "++${TRAVIS_SCALA_VERSION}" test

--- a/library/src/test/scala/DSL_0LexicalSpec.scala
+++ b/library/src/test/scala/DSL_0LexicalSpec.scala
@@ -31,8 +31,9 @@ class DSL_0LexicalSpec extends DSLSpec { def is =                             s2
     (LIT(1L)   must print_as("1L")) and
     (LIT(1.23F) must print_as("1.23F"))
   
+  // Symbol#toString changed in Scala 2.13.3, so we cannot hardcode expected result
   def literal3 =
-    LIT('Symbol) must print_as("'Symbol")
+    LIT('Symbol) must print_as('Symbol.toString)
 
   def literal4 =
     (TRUE  must print_as("true")) and


### PR DESCRIPTION
one test needed adjustment for the `Symbol#toString` change in Scala 2.13.3 (as caught by Scala community build)